### PR TITLE
container should return the same instance if a service is a singleton

### DIFF
--- a/lib/Container.js
+++ b/lib/Container.js
@@ -197,6 +197,10 @@ Container.prototype.constructService = function constructService(id, isOptional,
     }
   }
 
+  if (definition.isSingleton && this.services[id]) {
+    return this.services[id];
+  }
+
   // Try to load the constructor class for the service definition
   if (!definition.class) {
     if (this.isArgumentALiteral(definition.file)) {

--- a/test/lib/ContainerTest.js
+++ b/test/lib/ContainerTest.js
@@ -465,6 +465,27 @@ describe('lib/Container.js', function () {
       expect(container.services['some_service']).to.deep.equal(result);
     });
 
+    it('Should return the existing services if this is a singleton', function () {
+      var container, definition, test, result1, result2;
+      definition = new Definition();
+      definition.file = '%param%';
+      definition.isSingleton = true;
+
+      // Mock a require function that returns an object constructor
+      container = constructTestContainer();
+      container.require.withArgs('test_file');
+      container.set('some_service', definition);
+      container.setParameter('param', 'test_file');
+
+      test = {};
+      result1 = container.constructService('some_service', false, test);
+      result2 = container.get('some_service');
+
+      // Check that the returned objects are the same
+      expect(result1).to.deep.equal(result2);
+    });
+
+
     it('Should construct any arguments for Constructor Injection', function () {
       var container, definition, test, result;
       definition = new Definition();


### PR DESCRIPTION
Correct me if I'm wrong...if a service is marked as "isSingleton: true", then multiple calls to container.get() should return the same instance, but it is not.

You can try below -

My services.json:

```
{
  "parameters": {
    "my_singleton_service.class": "./MySingletonService"
  },
  "services": {
    "my_singleton_service": {
      "class": "%my_singleton_service.class%",
      "isSingleton": true
    }
  }
}
```

My singleton class (MySingletonService.js):

```
var MySingletonService = function () {
  this.buffer = [];
}

MySingletonService.prototype.addSomething = function (something) {
  this.buffer.push(something);
}

MySingletonService.prototype.getWhatYouHave = function () {
  return this.buffer;
}

module.exports = MySingletonService;
```

My test script (test_service_container.js):

```
var ServiceContainer = require('service-container');
var container = ServiceContainer.buildContainer(__dirname);

var obj1 = container.get('my_singleton_service');
obj1.addSomething('a');

// here obj2 should actually point to the same instance as obj1
var obj2 = container.get('my_singleton_service');
obj2.addSomething('b');

console.log("obj1 has: " + JSON.stringify(obj1.getWhatYouHave()));
console.log("obj2 has: " + JSON.stringify(obj2.getWhatYouHave()));
```

The output is:

```
obj1 has: ["a"]
obj2 has: ["b"]
```

Whereas, I think it should be:

```
obj1 has: ["a","b"]
obj2 has: ["a","b"]
```
