### PR TITLE
Based on comments by Mctigger, update service construction so constructor is only called once

### DIFF
--- a/lib/Container.js
+++ b/lib/Container.js
@@ -310,10 +310,10 @@ Container.prototype.constructService = function constructService(id, isOptional,
   if (definition.isObject) {
     svc = definition.class;
   } else if(definition.constructorMethod) {
-    svc = new definition.class[definition.constructorMethod]();
+    svc = Object.create(definition.class[definition.constructorMethod].prototype);
     definition.class[definition.constructorMethod].apply(svc, arguments);
   } else {
-    svc = new definition.class();
+    svc = Object.create(definition.class.prototype);
     definition.class.apply(svc, arguments);
   }
 


### PR DESCRIPTION
- Use Object.create() to copy the target class' prototype before applying its constructor
